### PR TITLE
Update wysihtml5-0.3.0.js

### DIFF
--- a/lib/wysihtml5/bootstrap-wysihtml5-0.0.2/wysihtml5-0.3.0.js
+++ b/lib/wysihtml5/bootstrap-wysihtml5-0.0.2/wysihtml5-0.3.0.js
@@ -171,7 +171,6 @@ window['rangy'] = (function() {
             if (areHostMethods(testRange, domRangeMethods) && areHostProperties(testRange, domRangeProperties)) {
                 implementsDomRange = true;
             }
-            testRange.detach();
         }
 
         var body = isHostObject(document, "body") ? document.body : document.getElementsByTagName("body")[0];


### PR DESCRIPTION
Removing that line to avoid a warning on Chrome that has annoyed me enough:
'Range.detach' is now a no-op, as per DOM (http://dom.spec.whatwg.org/#dom-range-detach).